### PR TITLE
Feature

### DIFF
--- a/cogs/grafana_discord_integration/grafana_discord_integration.py
+++ b/cogs/grafana_discord_integration/grafana_discord_integration.py
@@ -1,4 +1,3 @@
-
 import discord
 from dotenv import load_dotenv
 import asyncio
@@ -13,7 +12,7 @@ import json
 from discord import Button, ButtonStyle, InteractionType
 from typing import List
 
-#* Define the intents for the bot (this is required for the discord-py-slash-commands library)) 
+# * Define the intents for the bot (this is required for the discord-py-slash-commands library))
 intents = discord.Intents.default()
 intents.message_content = True
 intents.messages = True
@@ -21,128 +20,143 @@ intents.guilds = True
 intents.reactions = True
 intents.members = True
 
-#* Load the .env to get the discord and grafana tokens
+# * Load the .env to get the discord and grafana tokens
 load_dotenv()
 
-#section Code defining the Cog and its attributes/functions
+# section Code defining the Cog and its attributes/functions
+
 
 class Grafana_Discord_Integration_Cog(commands.Cog):
     def __init__(self, bot):
-        """ Initializes the cog and sets up the Grafana API integration"""
+        """Initializes the cog and sets up the Grafana API integration"""
         self.bot = bot
         self.logger = bot.logger
-        #todo dynamic dashboard names: If possible, get a list of the dashboard names from the grafana API
-        self.dashboard_names = ['minecraft-deep-dive-dashboard', 'minecraft-server-stats']
+        # todo dynamic dashboard names: If possible, get a list of the dashboard names from the grafana API
+        self.dashboard_names = [
+            "minecraft-deep-dive-dashboard",
+            "minecraft-server-stats",
+        ]
         self.panels = {}
         self.load_panel_config()
-        self.panel_source = os.getenv('GRAFANA_PANEL_SOURCE')
-        self.grafana_uid = os.getenv('GRAFANA_UID') 
-        self.grafana_url = os.getenv('GRAFANA_URL')
+        self.panel_source = os.getenv("GRAFANA_PANEL_SOURCE")
+        self.grafana_uid = os.getenv("GRAFANA_UID")
+        self.grafana_url = os.getenv("GRAFANA_URL")
         self.load_panel_config()
-        
+
     async def panel_autocomplete(
-            self,
-            interaction: discord.Interaction,
-            current: str) -> List[app_commands.Choice[str]]:
-        print('autocomplete invoked')
+        self, interaction: discord.Interaction, current: str
+    ) -> List[app_commands.Choice[str]]:
+        print("autocomplete invoked")
         return [
             app_commands.Choice(name=panel, value=panel)
-            for panel in self.panels if current.lower() in panel.lower()
+            for panel in self.panels
+            if current.lower() in panel.lower()
         ]
-    
-    #discord - Integration setup command group for use with the discord-py-slash-commands library, this will group the setup related commands beneath /set.    
-    grafanaset = app_commands.Group(name="grafanaset", description="Set up functions for the Grafana API Integration.")    
-    @grafanaset.command(name= "panel_source", description="Set up functions for the Grafana API Integration.")
-    async def set_panel_source(self, Interaction: discord.Interaction, panel_source: str):
+
+    # discord - Integration setup command group for use with the discord-py-slash-commands library, this will group the setup related commands beneath /set.
+    grafanaset = app_commands.Group(
+        name="grafanaset",
+        description="Set up functions for the Grafana API Integration.",
+    )
+
+    @grafanaset.command(
+        name="panel_source",
+        description="Set up functions for the Grafana API Integration.",
+    )
+    async def set_panel_source(
+        self, Interaction: discord.Interaction, panel_source: str
+    ):
         """
         Set the Grafana panel source.
         Usage: /set panel_source [panel_source]
         """
-        os.environ['GRAFANA_PANEL_SOURCE'] = panel_source
+        os.environ["GRAFANA_PANEL_SOURCE"] = panel_source
         self.panel_source = panel_source
         await Interaction.followup.send(f"Grafana panel source set to: {panel_source}")
-        
-    @grafanaset.command(name = "uid", description="Set up functions for the Grafana API Integration.")
+
+    @grafanaset.command(
+        name="uid", description="Set up functions for the Grafana API Integration."
+    )
     async def set_grafana_uid(self, Interaction: discord.Interaction, grafana_uid: str):
         """
         Set the Grafana UID.
         Usage: /set uid [grafana_uid]
         """
-        os.environ['GRAFANA_UID'] = grafana_uid
+        os.environ["GRAFANA_UID"] = grafana_uid
         self.grafana_uid = grafana_uid
         await Interaction.followup.send(f"Grafana UID set to: {grafana_uid}")
-        
-    @grafanaset.command(name = "url", description="Set the Grafana base url.")
+
+    @grafanaset.command(name="url", description="Set the Grafana base url.")
     async def set_grafana_url(self, Interaction: discord.Interaction, grafana_url: str):
         """
         Set the Grafana URL.
         Usage: /set url [grafana_url]
         """
-        os.environ['GRAFANA_URL'] = grafana_url
+        os.environ["GRAFANA_URL"] = grafana_url
         self.grafana_url = grafana_url
         await Interaction.followup.send(f"Grafana URL set to: {grafana_url}")
-    
-    
-        
-    #todo find a way to get the content of the json modal without requiring the user to download it
+
+    # todo find a way to get the content of the json modal without requiring the user to download it
     def load_panel_config(self):
-        """ Loads the panel names and ids from the json modal and stores them in a dictionary
+        """Loads the panel names and ids from the json modal and stores them in a dictionary
         :return: None
         """
-        jsonconfig_path = '.\grafana_dash_json_modal.json'
-        with open(jsonconfig_path, 'r') as file:
+        jsonconfig_path = ".\grafana_dash_json_modal.json"
+        with open(jsonconfig_path, "r") as file:
             json_modal = json.load(file)
             self.extract_panel_config(json_modal, self.panels)
             self.logger.info(f"Panel names and ids extracted from {jsonconfig_path}")
-            
-            
 
     def extract_panel_config(self, jsonconfig, panels, parent_id=None):
-        """ Recursively extracts the panel names and ids from the json modal and stores them in a dictionary
+        """Recursively extracts the panel names and ids from the json modal and stores them in a dictionary
         :param jsonconfig: The json modal to extract the panel names and ids from
         :param panels: The dictionary to store the panel names and ids in
         :param parent_id: The id of the parent panel
         :return: None
         """
         if isinstance(jsonconfig, dict):
-            panel_id = jsonconfig.get('id', parent_id)
-            if 'title' in jsonconfig and 'id' in jsonconfig:
-                panels[jsonconfig['title']] = jsonconfig['id']
+            panel_id = jsonconfig.get("id", parent_id)
+            if "title" in jsonconfig and "id" in jsonconfig:
+                panels[jsonconfig["title"]] = jsonconfig["id"]
             for key, value in jsonconfig.items():
                 self.extract_panel_config(value, panels, panel_id)
         elif isinstance(jsonconfig, list):
             for item in jsonconfig:
                 self.extract_panel_config(item, panels, parent_id)
 
-    #section Helper functions for requesting the panel and dashboard images from the Grafana API render engine 
+    # section Helper functions for requesting the panel and dashboard images from the Grafana API render engine
     async def fetch_rendered_panel(self, panel_name):
-        """ Fetches the panel image from the Grafana API and sends it to the Discord channel
+        """Fetches the panel image from the Grafana API and sends it to the Discord channel
         :param panel_name: The name of the panel to fetch
         :return: A discord.File object containing the panel image
         """
         panel_id = self.panels.get(panel_name)
-        if panel_id is not None: 
+        if panel_id is not None:
             api_key = os.getenv("GRAFANA_API_TOKEN")
-            panel_source =  self.panel_source
+            panel_source = self.panel_source
             grafana_url = self.grafana_url
             grafana_uid = self.grafana_uid
             grafana_api_url = f"https://{grafana_url}/render/d-solo/{grafana_uid}/{panel_source}?orgId=1&panelId={panel_id}"
-            headers = {'Authorization': f'Bearer {api_key}', 'Accept': 'image/png'}
+            headers = {"Authorization": f"Bearer {api_key}", "Accept": "image/png"}
             async with aiohttp.ClientSession() as session:
-                self.logger.info(f'Fetching panel: {panel_name}')
-                async with session.get(grafana_api_url, headers=headers) as api_response:
+                self.logger.info(f"Fetching panel: {panel_name}")
+                async with session.get(
+                    grafana_api_url, headers=headers
+                ) as api_response:
                     if api_response.status == 200:
                         content = await api_response.read()
                         image_stream = BytesIO(content)
                         image_stream.seek(0)
 
-                        self.logger.info('Panel image prepared for Discord channel')
+                        self.logger.info("Panel image prepared for Discord channel")
                         return discord.File(image_stream, filename="rendered_panel.png")
                     else:
-                        self.logger.error(f'Failed to fetch panel: {api_response.status}')
-                        
+                        self.logger.error(
+                            f"Failed to fetch panel: {api_response.status}"
+                        )
+
     async def fetch_rendered_multipanel(self, panel_names):
-        """ Performs the same API request as fetch_rendered_panel but for multiple panels, seperated by commas in panel_names interacton
+        """Performs the same API request as fetch_rendered_panel but for multiple panels, seperated by commas in panel_names interacton
         :param panel_names: A list of panel names to fetch
         :return: A list of discord.File objects containing the panel images
         """
@@ -154,14 +168,22 @@ class Grafana_Discord_Integration_Cog(commands.Cog):
                 # Add the panel file to the list penel_files
                 panel_files.append(panel_file)
         return panel_files
-    
-    async def dashboard_autocomplete(self, interaction: discord.Interaction, current: str):
-        """ Provides autocomplete suggestions for dashboard names """
+
+    async def dashboard_autocomplete(
+        self, interaction: discord.Interaction, current: str
+    ):
+        """Provides autocomplete suggestions for dashboard names"""
         dashboards = await self.dashboard_names()
-        return [dashboard for dashboard in dashboards if current.lower() in dashboard.lower()]
-    
-    async def fetch_rendered_dashboard(self, dashboard_name: str, width: int, height: int):
-        """ Fetches the dashboard image from the Grafana API and sends it to the Discord channel
+        return [
+            dashboard
+            for dashboard in dashboards
+            if current.lower() in dashboard.lower()
+        ]
+
+    async def fetch_rendered_dashboard(
+        self, dashboard_name: str, width: int, height: int
+    ):
+        """Fetches the dashboard image from the Grafana API and sends it to the Discord channel
         :param dashboard_name: The name of the dashboard to fetch
         :param width: The width of the dashboard image
         :param height: The height of the dashboard image
@@ -170,33 +192,44 @@ class Grafana_Discord_Integration_Cog(commands.Cog):
         api_key = os.getenv("GRAFANA_API_TOKEN")
         grafana_url = self.grafana_url
         grafana_uid = self.grafana_uid
-        grafana_api_url = f"https://{grafana_url}/render/d/{grafana_uid}/{dashboard_name}?orgId=1&width={width}&height={height}&kiosk=tv&from=now-1h&to=now&var-machine=&var-ideal=12"     
-        headers = {'Authorization': f'Bearer {api_key}', 'Accept': 'image/png'}
-        # Send the request to the Grafana API and stream the content to a BytesIO object which we can pass to discord as a file. 
+        grafana_api_url = f"https://{grafana_url}/render/d/{grafana_uid}/{dashboard_name}?orgId=1&width={width}&height={height}&kiosk=tv&from=now-1h&to=now&var-machine=&var-ideal=12"
+        headers = {"Authorization": f"Bearer {api_key}", "Accept": "image/png"}
+        # Send the request to the Grafana API and stream the content to a BytesIO object which we can pass to discord as a file.
         async with aiohttp.ClientSession() as session:
             async with session.get(grafana_api_url, headers=headers) as api_response:
-                self.logger.info(f'Fetching dashboard: {dashboard_name}')
+                self.logger.info(f"Fetching dashboard: {dashboard_name}")
                 if api_response.status == 200:
                     content = await api_response.read()
                     image_stream = BytesIO(content)
                     image_stream.seek(0)
-                    self.logger.info('Dashboard image prepared for Discord channel')
+                    self.logger.info("Dashboard image prepared for Discord channel")
                     return discord.File(image_stream, filename="rendered_dashboard.png")
                 else:
-                    self.logger.error(f'Failed to fetch dashboard: {api_response.status}')
- 
- 
-    #section Start of Discord bot commands. This command structure is based on the discord-py-slash-commands library
+                    self.logger.error(
+                        f"Failed to fetch dashboard: {api_response.status}"
+                    )
 
-    #todo: add autocomplete to the dashboard and panel names
-    #todo: secure the commands for server admin or moderator roles
-    
-    #discord - grafana command group for use with the discord-py-slash-commands library, this will group the grafana related commands beneath /grafana. 
-    #discord - due to the time it takes to fetch the dashboard and panel images, all grafana api interaction responses are deferred and the user is sent a message when the image is ready to be sent.
-    grafana = app_commands.Group(name="grafana", description="The Grafana discord integration cog is used to interact with the grafana API.")
+    # section Start of Discord bot commands. This command structure is based on the discord-py-slash-commands library
+
+    # todo: add autocomplete to the dashboard and panel names
+    # todo: secure the commands for server admin or moderator roles
+
+    # discord - grafana command group for use with the discord-py-slash-commands library, this will group the grafana related commands beneath /grafana.
+    # discord - due to the time it takes to fetch the dashboard and panel images, all grafana api interaction responses are deferred and the user is sent a message when the image is ready to be sent.
+    grafana = app_commands.Group(
+        name="grafana",
+        description="The Grafana discord integration cog is used to interact with the grafana API.",
+    )
+
     @grafana.command(name="dashboard", description="Display a Grafana dashboard")
-    async def grafana_dashboard(self, Interaction: discord.Interaction, dashboard_name: str, width: int = 1800, height: int = 1200):
-        """ Display a Grafana dashboard
+    async def grafana_dashboard(
+        self,
+        Interaction: discord.Interaction,
+        dashboard_name: str,
+        width: int = 1800,
+        height: int = 1200,
+    ):
+        """Display a Grafana dashboard
         Usage: /grafana dashboard [dashboard_name] [width] [height]
         """
         print("Command invoked: grafana_dashboard")  # Debug print
@@ -204,21 +237,29 @@ class Grafana_Discord_Integration_Cog(commands.Cog):
             return
         await Interaction.response.defer()
         try:
-            dashboard_data = await self.fetch_rendered_dashboard(dashboard_name, width, height)
+            dashboard_data = await self.fetch_rendered_dashboard(
+                dashboard_name, width, height
+            )
             if dashboard_data:
                 await Interaction.followup.send(file=dashboard_data)
-                self.logger.info(f"Dashboard {dashboard_name} sent to {Interaction.user.name}")
+                self.logger.info(
+                    f"Dashboard {dashboard_name} sent to {Interaction.user.name}"
+                )
             else:
-                await Interaction.followup.send("Failed to fetch the dashboard. Please check the dashboard name and try again.")
+                await Interaction.followup.send(
+                    "Failed to fetch the dashboard. Please check the dashboard name and try again."
+                )
         except Exception as e:
-            await Interaction.followup.send("An error occurred while fetching the dashboard.")
+            await Interaction.followup.send(
+                "An error occurred while fetching the dashboard."
+            )
             self.logger.error(f"Error fetching dashboard: {e}")
-    
+
     # Fetches the panel image from the Grafana API and sends it to the Discord channel
     @grafana.command(name="panel", description="Display a Grafana panel")
     @app_commands.autocomplete(panel_name=panel_autocomplete)
-    async def grafana_panel(self, interaction: discord.Interaction, panel_name: str): 
-        """ Display a Grafana panel
+    async def grafana_panel(self, interaction: discord.Interaction, panel_name: str):
+        """Display a Grafana panel
         Usage: /grafana panel [panel_name]
         """
         print("Command invoked: grafana_panel")  # Debug print
@@ -240,32 +281,43 @@ class Grafana_Discord_Integration_Cog(commands.Cog):
         except Exception as e:
             self.logger.error(f"Error fetching panel: {e}")
             print(f"Exception occurred: {e}")  # Debug print
-            await interaction.followup.send("An error occurred while fetching the panel.")
+            await interaction.followup.send(
+                "An error occurred while fetching the panel."
+            )
 
     # Same as the panel command, but will iterate through a list of panels seperated by commas in the panel_names interaction
     @grafana.command(name="multipanel", description="Display multiple Grafana panels")
-    async def grafana_multipanel(self, interaction: discord.Interaction, panel_names: str):
-        """ Display multiple Grafana panels
+    async def grafana_multipanel(
+        self, interaction: discord.Interaction, panel_names: str
+    ):
+        """Display multiple Grafana panels
         Usage: /grafana multipanel [panel_names]
         """
         await interaction.response.defer()
-        panel_list = [name.strip() for name in panel_names.split(',')]  # Split and strip names
+        panel_list = [
+            name.strip() for name in panel_names.split(",")
+        ]  # Split and strip names
         panel_files = await self.fetch_rendered_multipanel(panel_list)
         if panel_files:
             try:
                 await interaction.followup.send(files=panel_files)
             except Exception as e:
                 self.logger.error(f"Error sending panel files: {e}")
-                await interaction.followup.send("An error occurred while sending the panels.")
+                await interaction.followup.send(
+                    "An error occurred while sending the panels."
+                )
         else:
-            await interaction.followup.send("No panels were found or an error occurred.")
-            
-        
-    #section: Interactive commands using Discord components
-    
-    @grafana.command(name="ipanel", description="Copy a Grafana panel with time range buttons")
+            await interaction.followup.send(
+                "No panels were found or an error occurred."
+            )
+
+    # section: Interactive commands using Discord components
+
+    @grafana.command(
+        name="ipanel", description="Copy a Grafana panel with time range buttons"
+    )
     async def grafana_ipanel(self, interaction: discord.Interaction, panel_name: str):
-        """ Render a Grafana Panel with time range buttons
+        """Render a Grafana Panel with time range buttons
         Usage: /grafana ipanel [panel_name]
         """
         await interaction.response.defer()
@@ -279,7 +331,9 @@ class Grafana_Discord_Integration_Cog(commands.Cog):
             Button(style=ButtonStyle.blue, label="7d", custom_id="7d"),
             Button(style=ButtonStyle.blue, label="30d", custom_id="30d"),
         ]
-        await interaction.followup.send("Choose the panel time scope:", view=view, components=[buttons])
+        await interaction.followup.send(
+            "Choose the panel time scope:", view=view, components=[buttons]
+        )
 
     @commands.Cog.listener()
     async def on_button_click(interaction):
@@ -290,35 +344,38 @@ class Grafana_Discord_Integration_Cog(commands.Cog):
                 components=[],
             )
             # TODO: Implement logic to fetch and send the panel image with the selected time range
-        
-        
+
     #! Needs work
-    #todo: improve the display of the panels, maybe use a select menu
-    @grafana.command(name="listpanels", description="List all panels available to display")
+    # todo: improve the display of the panels, maybe use a select menu
+    @grafana.command(
+        name="listpanels", description="List all panels available to display"
+    )
     async def grafana_listpanels(self, Interaction: discord.Interaction):
-        """ List all panels available to display
+        """List all panels available to display
         Usage: /grafana listpanels
         """
         panel_options = list(self.panels.keys())
         midpoint = len(panel_options) // 2
-        embed = discord.Embed(title="Grafana - Available Panels", color=discord.Color.blue())
+        embed = discord.Embed(
+            title="Grafana - Available Panels", color=discord.Color.blue()
+        )
         # Splitting the panel options into two columns for the embed
         column1 = panel_options[:midpoint]
         column2 = panel_options[midpoint:]  # Fix: Define column2
         # Add the panel names to an embed
         for entry1, entry2 in zip(column1, column2):
-            embed.add_field(name=entry1, value=entry2, inline=True)  # Fix: Set value to entry2
-            embed.add_field(name=entry2, value='\u200b', inline=True)
-            embed.add_field(name='\u200b', value='\u200b', inline=True)  # Spacer
+            embed.add_field(
+                name=entry1, value=entry2, inline=True
+            )  # Fix: Set value to entry2
+            embed.add_field(name=entry2, value="\u200b", inline=True)
+            embed.add_field(name="\u200b", value="\u200b", inline=True)  # Spacer
 
         await Interaction.response.send_message(embed=embed)
         self.logger.info(f"Panel list sent to {Interaction.user.name}")
-            
+
 
 async def setup(bot):
-    """ Adds the cog to the bot
+    """Adds the cog to the bot
     :param bot: The bot to add the cog to
     :return: None"""
     await bot.add_cog(Grafana_Discord_Integration_Cog(bot))
-    
-        

--- a/cogs/quantum_pterodactyl/quantum_pterodactyl.py
+++ b/cogs/quantum_pterodactyl/quantum_pterodactyl.py
@@ -49,7 +49,7 @@ class QuantumPterodactyl(commands.Cog):
         embed = discord.Embed(
             title="QuantumPterodactyl Commands",
             description="List of all available commands",
-            color=discord.Color.blue(),
+            color=discord.Color.purple(),
         )
         for command in commands_list:
             name, description = command.split(" - ")

--- a/cogs/quantum_pterodactyl/quantum_pterodactyl.py
+++ b/cogs/quantum_pterodactyl/quantum_pterodactyl.py
@@ -1,7 +1,6 @@
-
-# QuantumPterodactyl: A cog which uses Discord Interactions to send commands to the Pterodactyl server API. 
-# 
-#Author:
+# QuantumPterodactyl: A cog which uses Discord Interactions to send commands to the Pterodactyl server API.
+#
+# Author:
 #    Dave Chadwick (github.com/ropeadope62)
 # Version:
 #    0.1
@@ -15,21 +14,24 @@ import os
 from dotenv import load_dotenv
 import logging
 
+
 class QuantumPterodactyl(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         # We will use the same logger as we use for the client in QCAdmin loaded cogs
         self.logger = bot.logger
         load_dotenv()
-        self.api_key = os.getenv('PTERODACTYL_API_KEY')
-        self.panel_url = os.getenv('PTERODACTYL_PANEL_URL')  
-        self.server_id = os.getenv('PTERODACTYL_SERVER_ID')
-        
+        self.api_key = os.getenv("PTERODACTYL_API_KEY")
+        self.panel_url = os.getenv("PTERODACTYL_PANEL_URL")
+        self.server_id = os.getenv("PTERODACTYL_SERVER_ID")
+
         if not all([self.api_key, self.panel_url, self.server_id]):
             self.logger.error("Missing required Pterodactyl dotenv variables")
             raise ValueError("Missing required Pterodactyl dotenv variables")
-        
-    @app_commands.command(name="commands", description="List all QuantumPterodactyl commands")
+
+    @app_commands.command(
+        name="commands", description="List all QuantumPterodactyl commands"
+    )
     async def list_commands(self, interaction: discord.Interaction):
         """QuantumPterodactyl command list:"""
         commands_list = [
@@ -38,21 +40,27 @@ class QuantumPterodactyl(commands.Cog):
             "/power stop <serverid:str> - Stops the game server gracefully",
             "/power restart <serverid:str> - Restarts the game server",
             "/power kill <serverid:str> - Forcefully stops the game server",
-            "/commands - Lists all available QuantumPterodactyl commands"
+            "/commands - Lists all available QuantumPterodactyl commands",
         ]
         commands_message = "\n".join(commands_list)
-        await interaction.response.send_message(f"**QuantumPterodactyl Commands:**\n{commands_message}")
-        embed = discord.Embed(title="QuantumPterodactyl Commands", description="List of all available commands", color=discord.Color.blue())
+        await interaction.response.send_message(
+            f"**QuantumPterodactyl Commands:**\n{commands_message}"
+        )
+        embed = discord.Embed(
+            title="QuantumPterodactyl Commands",
+            description="List of all available commands",
+            color=discord.Color.blue(),
+        )
         for command in commands_list:
             name, description = command.split(" - ")
             embed.add_field(name=name, value=description, inline=False)
-        
+
         await interaction.response.send_message(embed=embed)
-        
+
     async def _send_power_signal(self, signal: str, server_id: str) -> tuple[bool, str]:
         """
         Send a power signal to the Quantumly Confused Pterodactyl server.
-        
+
         Args:
             signal (str): One of 'start', 'stop', 'restart', 'kill'
             server_id (str): The server ID to target for the power signal
@@ -61,7 +69,7 @@ class QuantumPterodactyl(commands.Cog):
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
-            "Accept": "application/json"
+            "Accept": "application/json",
         }
         data = {"signal": signal}
 
@@ -69,34 +77,44 @@ class QuantumPterodactyl(commands.Cog):
             async with aiohttp.ClientSession() as session:
                 async with session.post(url, headers=headers, json=data) as response:
                     if response.status == 204:  # Success with no content
-                        self.logger.info(f"Successfully sent {signal} signal to server {server_id}")
-                        return True, f"Successfully sent {signal} signal to server {server_id}"
+                        self.logger.info(
+                            f"Successfully sent {signal} signal to server {server_id}"
+                        )
+                        return (
+                            True,
+                            f"Successfully sent {signal} signal to server {server_id}",
+                        )
                     else:
                         error_text = await response.text()
                         self.logger.error(f"Pterodactyl API error: {error_text}")
-                        return False, f"Failed to send {signal} signal. Status: {response.status}"
+                        return (
+                            False,
+                            f"Failed to send {signal} signal. Status: {response.status}",
+                        )
         except Exception as e:
-            self.logger.error(f"Error sending power signal to server {server_id}: {str(e)}")
+            self.logger.error(
+                f"Error sending power signal to server {server_id}: {str(e)}"
+            )
             return False, f"Error occurred: {str(e)}"
 
-
     power = app_commands.Group(name="power", description="Control server power state.")
-    
+
     @power.command(name="start")
     @app_commands.checks.has_permissions(administrator=True)
     async def start_server(self, interaction: discord.Interaction, server_id: str):
         """Starts the specified game server"""
-        await interaction.response.defer() #Discord: always defer the response when using interactions that may take longer than 3 seconds to respond
-        
+        await interaction.response.defer()  # Discord: always defer the response when using interactions that may take longer than 3 seconds to respond
+
         success, message = await self._send_power_signal("start", server_id)
-        
+
         if success:
             await interaction.followup.send(f"🟢 Server `{server_id}` is starting up...")
             self.logger.info(f"Server `{server_id}` is starting up")
         else:
-            await interaction.followup.send(f"❌ Failed to start server `{server_id}`: {message}")
+            await interaction.followup.send(
+                f"❌ Failed to start server `{server_id}`: {message}"
+            )
             self.logger.error(f"Failed to start server `{server_id}`: {message}")
-
 
     @power.command(name="stop")
     @app_commands.checks.has_permissions(administrator=True)
@@ -105,14 +123,17 @@ class QuantumPterodactyl(commands.Cog):
         await interaction.response.defer()
 
         success, message = await self._send_power_signal("stop", server_id)
-        
+
         if success:
-            await interaction.followup.send(f"🔴 Server `{server_id}` is shutting down...")
+            await interaction.followup.send(
+                f"🔴 Server `{server_id}` is shutting down..."
+            )
             self.logger.info(f"Server `{server_id}` is shutting down")
         else:
-            await interaction.followup.send(f"❌ Failed to stop server `{server_id}`: {message}")
+            await interaction.followup.send(
+                f"❌ Failed to stop server `{server_id}`: {message}"
+            )
             self.logger.error(f"Failed to stop server `{server_id}`: {message}")
-
 
     @power.command(name="restart")
     @app_commands.checks.has_permissions(administrator=True)
@@ -121,14 +142,15 @@ class QuantumPterodactyl(commands.Cog):
         await interaction.response.defer()
 
         success, message = await self._send_power_signal("restart", server_id)
-        
+
         if success:
             await interaction.followup.send(f"🔄 Server `{server_id}` is restarting...")
             self.logger.info(f"Server `{server_id}` is restarting")
         else:
-            await interaction.followup.send(f"❌ Failed to restart server `{server_id}`: {message}")
+            await interaction.followup.send(
+                f"❌ Failed to restart server `{server_id}`: {message}"
+            )
             self.logger.error(f"Failed to restart server `{server_id}`: {message}")
-
 
     @power.command(name="kill")
     @app_commands.checks.has_permissions(administrator=True)
@@ -137,14 +159,18 @@ class QuantumPterodactyl(commands.Cog):
         await interaction.response.defer()
 
         success, message = await self._send_power_signal("kill", server_id)
-        
+
         if success:
-            await interaction.followup.send(f"⚠️ Server `{server_id}` has been forcefully stopped!")
+            await interaction.followup.send(
+                f"⚠️ Server `{server_id}` has been forcefully stopped!"
+            )
             self.logger.warning(f"Server `{server_id}` has been forcefully stopped")
         else:
-            await interaction.followup.send(f"❌ Failed to kill server `{server_id}`: {message}")
+            await interaction.followup.send(
+                f"❌ Failed to kill server `{server_id}`: {message}"
+            )
             self.logger.error(f"Failed to kill server `{server_id}`: {message}")
-    
+
     @power.command(name="state")
     @app_commands.checks.has_permissions(administrator=True)
     async def power_state(self, interaction: discord.Interaction, server_id: str):
@@ -155,7 +181,7 @@ class QuantumPterodactyl(commands.Cog):
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Accept": "application/json",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
 
         try:
@@ -163,232 +189,43 @@ class QuantumPterodactyl(commands.Cog):
                 async with session.get(url, headers=headers) as response:
                     if response.status == 200:
                         data = await response.json()
-                        power_state = data.get('attributes', {}).get('current_state', 'Unknown')
+                        power_state = data.get("attributes", {}).get(
+                            "current_state", "Unknown"
+                        )
 
                         # Send the power state as a message
-                        await interaction.followup.send(f"The current power state of server `{server_id}` is: `{power_state}`")
-                        self.logger.info(f"Power state fetched for server `{server_id}`: {power_state}")
-                    else:
-                        error_text = await response.text()
-                        self.logger.error(f"Pterodactyl API error: {error_text}")
-                        await interaction.followup.send(f"❌ Failed to fetch power state. Status: {response.status}")
-        except Exception as e:
-            self.logger.error(f"Error fetching power state for server `{server_id}`: {str(e)}")
-            await interaction.followup.send(f"❌ Error occurred: {str(e)}")
-            
-    server = app_commands.Group(name="server", description="Server information.")
-    
-    @server.command(name="list", description="List all game servers")
-    @app_commands.checks.has_permissions(administrator=True, manage_guild=True)
-    async def list_servers(self, interaction: discord.Interaction):
-        """
-        Lists all servers associated with the Pterodactyl panel.
-        """
-        await interaction.response.defer()
-
-        url = f"{self.panel_url}/api/client/servers"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Accept": "application/json"
-        }
-
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, headers=headers) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        server_list = [f"{server['attributes']['name']} (ID: {server['attributes']['id']})" for server in data['data']]
-                        formatted_list = "\n".join(server_list)
-                        await interaction.followup.send(f"**Servers:**\n{formatted_list}")
-                    else:
-                        error_text = await response.text()
-                        self.logger.error(f"Pterodactyl API error: {error_text}")
-                        await interaction.followup.send(f"❌ Failed to list servers. Status: {response.status}")
-        except Exception as e:
-            self.logger.error(f"Error listing servers: {str(e)}")
-            await interaction.followup.send(f"❌ Error occurred: {str(e)}")
-        
-    
-    
-# QuantumPterodactyl: A cog which uses Discord Interactions to send commands to the Pterodactyl server API. 
-# 
-#Author:
-#    Dave Chadwick (github.com/ropeadope62)
-# Version:
-#    0.1
-
-
-import discord
-from discord import app_commands
-from discord.ext import commands
-import aiohttp
-import os
-from dotenv import load_dotenv
-import logging
-
-class QuantumPterodactyl(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
-        # We will use the same logger as we use for the client in QCAdmin loaded cogs
-        self.logger = bot.logger
-        load_dotenv()
-        self.api_key = os.getenv('PTERODACTYL_API_KEY')
-        self.panel_url = os.getenv('PTERODACTYL_PANEL_URL')  
-        self.server_id = os.getenv('PTERODACTYL_SERVER_ID')
-        
-        if not all([self.api_key, self.panel_url, self.server_id]):
-            self.logger.error("Missing required Pterodactyl dotenv variables")
-            raise ValueError("Missing required Pterodactyl dotenv variables")
-        
-    @app_commands.command(name="commands", description="List all QuantumPterodactyl commands")
-    async def list_commands(self, interaction: discord.Interaction):
-        """QuantumPterodactyl command list:"""
-        commands_list = [
-            
-            "/power start - Starts the game server",
-            "/power stop - Stops the game server gracefully",
-            "/power restart - Restarts the game server",
-            "/power kill - Forcefully stops the game server",
-            "/server list - Lists all game servers",
-            "/server info - Get server information",
-            "/commands - Lists all available QuantumPterodactyl commands"
-        ]
-        commands_message = "\n".join(commands_list)
-        await interaction.response.send_message(f"**QuantumPterodactyl Commands:**\n{commands_message}")
-        embed = discord.Embed(title="QuantumPterodactyl Commands", description="List of all available commands", color=discord.Color.blue())
-        for command in commands_list:
-            name, description = command.split(" - ")
-            embed.add_field(name=name, value=description, inline=False)
-        
-        await interaction.response.send_message(embed=embed)
-        
-    async def _send_power_signal(self, signal: str) -> tuple[bool, str]:
-        """
-        Send a power signal to the Quantumly Confused Pterodactyl server.
-        
-        Args:
-            signal (str): One of 'start', 'stop', 'restart', 'kill'
-        """
-        url = f"{self.panel_url}/api/client/servers/{self.server_id}/power"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-            "Accept": "application/json"
-        }
-        data = {"signal": signal}
-
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(url, headers=headers, json=data) as response:
-                    if response.status == 204:  # Success with no content
-                        self.logger.info(f"Successfully sent {signal} signal to server")
-                        return True, f"Successfully sent {signal} signal to server"
-                    else:
-                        error_text = await response.text()
-                        self.logger.error(f"Pterodactyl API error: {error_text}")
-                        return False, f"Failed to send {signal} signal. Status: {response.status}"
-        except Exception as e:
-            self.logger.error(f"Error sending power signal: {str(e)}")
-            return False, f"Error occurred: {str(e)}"
-
-    power = app_commands.Group(name="power", description="Control server power state.")
-    
-    @power.command(name="stop")
-    @app_commands.checks.has_permissions(administrator=True)
-    async def stop_server(self, interaction: discord.Interaction, server_id: str):
-        """Stops the specified game server gracefully"""
-        await interaction.response.defer() #Discord: with interactions its common to defer the response so that the interaction doesn't time out (3s) while the command is being processed
-
-        success, message = await self._send_power_signal("stop", server_id)
-        
-        if success:
-            await interaction.followup.send(f"🔴 Server `{server_id}` is shutting down...")
-            self.logger.info(f"Server `{server_id}` is shutting down")
-        else:
-            await interaction.followup.send(f"❌ Failed to stop server `{server_id}`: {message}")
-            self.logger.error(f"Failed to stop server `{server_id}`: {message}")
-
-    @power.command(name="restart")
-    @app_commands.checks.has_permissions(administrator=True)
-    async def restart_server(self, interaction: discord.Interaction, server_id: str):
-        """Restarts the specified game server"""
-        await interaction.response.defer() #Discord: Defer all interactions which may take longer than 3 seconds to respond
-
-        success, message = await self._send_power_signal("restart", server_id)
-        
-        if success:
-            await interaction.followup.send(f"🔄 Server `{server_id}` is restarting...")
-            self.logger.info(f"Server `{server_id}` is restarting")
-        else:
-            await interaction.followup.send(f"❌ Failed to restart server `{server_id}`: {message}")
-            self.logger.error(f"Failed to restart server `{server_id}`: {message}")
-
-    @power.command(name="kill")
-    @app_commands.checks.has_permissions(administrator=True)
-    async def kill_server(self, interaction: discord.Interaction, server_id: str):
-        """Forcefully stops the specified game server"""
-        await interaction.response.defer() 
-
-        success, message = await self._send_power_signal("kill", server_id)
-        
-        if success:
-            await interaction.followup.send(f"⚠️ Server `{server_id}` has been forcefully stopped!")
-            self.logger.warning(f"Server `{server_id}` has been forcefully stopped")
-        else:
-            await interaction.followup.send(f"❌ Failed to kill server `{server_id}`: {message}")
-            self.logger.error(f"Failed to kill server `{server_id}`: {message}")
-            
-    server = app_commands.Group(name="server", description="Server information.") #Discord: Define the app command group for 'server' commands
-    
-    @server.command(name="list", description="List all game servers")
-    @app_commands.checks.has_permissions(administrator=True, manage_guild=True)
-    async def list_servers(self, interaction: discord.Interaction):
-        """
-        Lists all servers associated with the Pterodactyl panel.
-        """
-        await interaction.response.defer() 
-
-        url = f"{self.panel_url}/api/client/servers"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Accept": "application/json"
-        }
-
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, headers=headers) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        server_list = [f"**{server['attributes']['name']}** (ID: {server['attributes']['id']})" for server in data['data']]
-
-                        embed = discord.Embed(
-                            title="Pterodactyl Servers",
-                            description="\n".join(server_list),
-                            color=discord.Color.purple()
+                        await interaction.followup.send(
+                            f"The current power state of server `{server_id}` is: `{power_state}`"
                         )
-                        await interaction.followup.send(embed=embed)
+                        self.logger.info(
+                            f"Power state fetched for server `{server_id}`: {power_state}"
+                        )
                     else:
                         error_text = await response.text()
                         self.logger.error(f"Pterodactyl API error: {error_text}")
-                        await interaction.followup.send(f"❌ Failed to list servers. Status: {response.status}")
+                        await interaction.followup.send(
+                            f"❌ Failed to fetch power state. Status: {response.status}"
+                        )
         except Exception as e:
-            self.logger.error(f"Error listing servers: {str(e)}")
+            self.logger.error(
+                f"Error fetching power state for server `{server_id}`: {str(e)}"
+            )
             await interaction.followup.send(f"❌ Error occurred: {str(e)}")
-        
-        
-    @server.command(name="details", description="Get detailed information about a specific server")
+
+    server = app_commands.Group(name="server", description="Server information.")
+
+    @server.command(name="list", description="List all game servers")
     @app_commands.checks.has_permissions(administrator=True, manage_guild=True)
-    async def server_details(self, interaction: discord.Interaction, server_id: str = None):
-        """Fetches and displays detailed server information."""
+    async def list_servers(self, interaction: discord.Interaction):
+        """
+        Lists all servers associated with the Pterodactyl panel.
+        """
         await interaction.response.defer()
 
-        # Use provided server_id or default to self.server_id
-        server_id = server_id or self.server_id
-        url = f"{self.panel_url}/api/application/servers/{server_id}"
+        url = f"{self.panel_url}/api/client/servers"
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Accept": "application/json",
-            "Content-Type": "application/json"
         }
 
         try:
@@ -396,72 +233,25 @@ class QuantumPterodactyl(commands.Cog):
                 async with session.get(url, headers=headers) as response:
                     if response.status == 200:
                         data = await response.json()
-                        attributes = data['attributes']
-
-                        # Extract core data, we can add more fields if needed this is not an exhaustive list of attributes
-                        server_name = attributes.get("name", "N/A")
-                        description = attributes.get("description", "No description provided")
-                        uuid = attributes.get("uuid", "N/A")
-                        identifier = attributes.get("identifier", "N/A")
-                        suspended = "Yes" if attributes.get("suspended") else "No"
-
-                        # Limits
-                        limits = attributes.get("limits", {})
-                        memory = limits.get("memory", "N/A")
-                        swap = limits.get("swap", "N/A")
-                        disk = limits.get("disk", "N/A")
-                        io = limits.get("io", "N/A")
-                        cpu = limits.get("cpu", "N/A")
-
-                        # Feature Limits
-                        feature_limits = attributes.get("feature_limits", {})
-                        databases = feature_limits.get("databases", "N/A")
-                        allocations = feature_limits.get("allocations", "N/A")
-                        backups = feature_limits.get("backups", "N/A")
-
-                        # Container Information
-                        container = attributes.get("container", {})
-                        startup_command = container.get("startup_command", "N/A")
-                        image = container.get("image", "N/A")
-                        installed = "Yes" if container.get("installed") else "No"
-
-                        # Embed creation
-                        embed = discord.Embed(
-                            title=f"Server Details: {server_name}",
-                            description=description,
-                            color=discord.Color.purple()
+                        server_list = [
+                            f"{server['attributes']['name']} (ID: {server['attributes']['id']})"
+                            for server in data["data"]
+                        ]
+                        formatted_list = "\n".join(server_list)
+                        await interaction.followup.send(
+                            f"**Servers:**\n{formatted_list}"
                         )
-                        embed.add_field(name="UUID", value=uuid, inline=False)
-                        embed.add_field(name="Identifier", value=identifier, inline=True)
-                        embed.add_field(name="Suspended", value=suspended, inline=True)
-
-                        # Limits
-                        embed.add_field(name="Memory Limit", value=f"{memory} MB", inline=True)
-                        embed.add_field(name="Swap Limit", value=f"{swap} MB", inline=True)
-                        embed.add_field(name="Disk Limit", value=f"{disk} MB", inline=True)
-                        embed.add_field(name="I/O Limit", value=io, inline=True)
-                        embed.add_field(name="CPU Limit", value=cpu, inline=True)
-
-                        # Feature Limits
-                        embed.add_field(name="Databases", value=databases, inline=True)
-                        embed.add_field(name="Allocations", value=allocations, inline=True)
-                        embed.add_field(name="Backups", value=backups, inline=True)
-
-                        # Container Info
-                        embed.add_field(name="Startup Command", value=startup_command, inline=False)
-                        embed.add_field(name="Image", value=image, inline=True)
-                        embed.add_field(name="Installed", value=installed, inline=True)
-
-                        # Additional Information
-                        embed.set_footer(text=f"Created at: {attributes.get('created_at', 'N/A')}\nUpdated at: {attributes.get('updated_at', 'N/A')}")
-
-                        await interaction.followup.send(embed=embed)
-                        self.logger.info(f"Server details fetched successfully for server ID: {server_id}")
                     else:
                         error_text = await response.text()
                         self.logger.error(f"Pterodactyl API error: {error_text}")
-                        await interaction.followup.send(f"❌ Failed to fetch server details. Status: {response.status}")
+                        await interaction.followup.send(
+                            f"❌ Failed to list servers. Status: {response.status}"
+                        )
         except Exception as e:
-            self.logger.error(f"Error fetching server details: {str(e)}")
+            self.logger.error(f"Error listing servers: {str(e)}")
             await interaction.followup.send(f"❌ Error occurred: {str(e)}")
 
+
+async def setup(bot):
+    await bot.add_cog(QuantumPterodactyl(bot))
+    bot.logger.info("Cog loaded: QuantumPterodactyl v0.1")

--- a/cogs/quantum_pterodactyl/quantum_pterodactyl.py
+++ b/cogs/quantum_pterodactyl/quantum_pterodactyl.py
@@ -33,10 +33,224 @@ class QuantumPterodactyl(commands.Cog):
     async def list_commands(self, interaction: discord.Interaction):
         """QuantumPterodactyl command list:"""
         commands_list = [
+            "/power state <serverid:str> - Get the current state of the game server",
+            "/power start <serverid:str> - Starts the game server",
+            "/power stop <serverid:str> - Stops the game server gracefully",
+            "/power restart <serverid:str> - Restarts the game server",
+            "/power kill <serverid:str> - Forcefully stops the game server",
+            "/commands - Lists all available QuantumPterodactyl commands"
+        ]
+        commands_message = "\n".join(commands_list)
+        await interaction.response.send_message(f"**QuantumPterodactyl Commands:**\n{commands_message}")
+        embed = discord.Embed(title="QuantumPterodactyl Commands", description="List of all available commands", color=discord.Color.blue())
+        for command in commands_list:
+            name, description = command.split(" - ")
+            embed.add_field(name=name, value=description, inline=False)
+        
+        await interaction.response.send_message(embed=embed)
+        
+    async def _send_power_signal(self, signal: str, server_id: str) -> tuple[bool, str]:
+        """
+        Send a power signal to the Quantumly Confused Pterodactyl server.
+        
+        Args:
+            signal (str): One of 'start', 'stop', 'restart', 'kill'
+            server_id (str): The server ID to target for the power signal
+        """
+        url = f"{self.panel_url}/api/client/servers/{server_id}/power"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        }
+        data = {"signal": signal}
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, headers=headers, json=data) as response:
+                    if response.status == 204:  # Success with no content
+                        self.logger.info(f"Successfully sent {signal} signal to server {server_id}")
+                        return True, f"Successfully sent {signal} signal to server {server_id}"
+                    else:
+                        error_text = await response.text()
+                        self.logger.error(f"Pterodactyl API error: {error_text}")
+                        return False, f"Failed to send {signal} signal. Status: {response.status}"
+        except Exception as e:
+            self.logger.error(f"Error sending power signal to server {server_id}: {str(e)}")
+            return False, f"Error occurred: {str(e)}"
+
+
+    power = app_commands.Group(name="power", description="Control server power state.")
+    
+    @power.command(name="start")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def start_server(self, interaction: discord.Interaction, server_id: str):
+        """Starts the specified game server"""
+        await interaction.response.defer() #Discord: always defer the response when using interactions that may take longer than 3 seconds to respond
+        
+        success, message = await self._send_power_signal("start", server_id)
+        
+        if success:
+            await interaction.followup.send(f"🟢 Server `{server_id}` is starting up...")
+            self.logger.info(f"Server `{server_id}` is starting up")
+        else:
+            await interaction.followup.send(f"❌ Failed to start server `{server_id}`: {message}")
+            self.logger.error(f"Failed to start server `{server_id}`: {message}")
+
+
+    @power.command(name="stop")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def stop_server(self, interaction: discord.Interaction, server_id: str):
+        """Stops the specified game server gracefully"""
+        await interaction.response.defer()
+
+        success, message = await self._send_power_signal("stop", server_id)
+        
+        if success:
+            await interaction.followup.send(f"🔴 Server `{server_id}` is shutting down...")
+            self.logger.info(f"Server `{server_id}` is shutting down")
+        else:
+            await interaction.followup.send(f"❌ Failed to stop server `{server_id}`: {message}")
+            self.logger.error(f"Failed to stop server `{server_id}`: {message}")
+
+
+    @power.command(name="restart")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def restart_server(self, interaction: discord.Interaction, server_id: str):
+        """Restarts the specified game server"""
+        await interaction.response.defer()
+
+        success, message = await self._send_power_signal("restart", server_id)
+        
+        if success:
+            await interaction.followup.send(f"🔄 Server `{server_id}` is restarting...")
+            self.logger.info(f"Server `{server_id}` is restarting")
+        else:
+            await interaction.followup.send(f"❌ Failed to restart server `{server_id}`: {message}")
+            self.logger.error(f"Failed to restart server `{server_id}`: {message}")
+
+
+    @power.command(name="kill")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def kill_server(self, interaction: discord.Interaction, server_id: str):
+        """Forcefully stops the specified game server"""
+        await interaction.response.defer()
+
+        success, message = await self._send_power_signal("kill", server_id)
+        
+        if success:
+            await interaction.followup.send(f"⚠️ Server `{server_id}` has been forcefully stopped!")
+            self.logger.warning(f"Server `{server_id}` has been forcefully stopped")
+        else:
+            await interaction.followup.send(f"❌ Failed to kill server `{server_id}`: {message}")
+            self.logger.error(f"Failed to kill server `{server_id}`: {message}")
+    
+    @power.command(name="state")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def power_state(self, interaction: discord.Interaction, server_id: str):
+        """Fetches and displays the current power state of the specified server"""
+        await interaction.response.defer()
+
+        url = f"{self.panel_url}/api/client/servers/{server_id}/resources"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        }
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, headers=headers) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        power_state = data.get('attributes', {}).get('current_state', 'Unknown')
+
+                        # Send the power state as a message
+                        await interaction.followup.send(f"The current power state of server `{server_id}` is: `{power_state}`")
+                        self.logger.info(f"Power state fetched for server `{server_id}`: {power_state}")
+                    else:
+                        error_text = await response.text()
+                        self.logger.error(f"Pterodactyl API error: {error_text}")
+                        await interaction.followup.send(f"❌ Failed to fetch power state. Status: {response.status}")
+        except Exception as e:
+            self.logger.error(f"Error fetching power state for server `{server_id}`: {str(e)}")
+            await interaction.followup.send(f"❌ Error occurred: {str(e)}")
+            
+    server = app_commands.Group(name="server", description="Server information.")
+    
+    @server.command(name="list", description="List all game servers")
+    @app_commands.checks.has_permissions(administrator=True, manage_guild=True)
+    async def list_servers(self, interaction: discord.Interaction):
+        """
+        Lists all servers associated with the Pterodactyl panel.
+        """
+        await interaction.response.defer()
+
+        url = f"{self.panel_url}/api/client/servers"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json"
+        }
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, headers=headers) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        server_list = [f"{server['attributes']['name']} (ID: {server['attributes']['id']})" for server in data['data']]
+                        formatted_list = "\n".join(server_list)
+                        await interaction.followup.send(f"**Servers:**\n{formatted_list}")
+                    else:
+                        error_text = await response.text()
+                        self.logger.error(f"Pterodactyl API error: {error_text}")
+                        await interaction.followup.send(f"❌ Failed to list servers. Status: {response.status}")
+        except Exception as e:
+            self.logger.error(f"Error listing servers: {str(e)}")
+            await interaction.followup.send(f"❌ Error occurred: {str(e)}")
+        
+    
+    
+# QuantumPterodactyl: A cog which uses Discord Interactions to send commands to the Pterodactyl server API. 
+# 
+#Author:
+#    Dave Chadwick (github.com/ropeadope62)
+# Version:
+#    0.1
+
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+import aiohttp
+import os
+from dotenv import load_dotenv
+import logging
+
+class QuantumPterodactyl(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        # We will use the same logger as we use for the client in QCAdmin loaded cogs
+        self.logger = bot.logger
+        load_dotenv()
+        self.api_key = os.getenv('PTERODACTYL_API_KEY')
+        self.panel_url = os.getenv('PTERODACTYL_PANEL_URL')  
+        self.server_id = os.getenv('PTERODACTYL_SERVER_ID')
+        
+        if not all([self.api_key, self.panel_url, self.server_id]):
+            self.logger.error("Missing required Pterodactyl dotenv variables")
+            raise ValueError("Missing required Pterodactyl dotenv variables")
+        
+    @app_commands.command(name="commands", description="List all QuantumPterodactyl commands")
+    async def list_commands(self, interaction: discord.Interaction):
+        """QuantumPterodactyl command list:"""
+        commands_list = [
+            
             "/power start - Starts the game server",
             "/power stop - Stops the game server gracefully",
             "/power restart - Restarts the game server",
             "/power kill - Forcefully stops the game server",
+            "/server list - Lists all game servers",
+            "/server info - Get server information",
             "/commands - Lists all available QuantumPterodactyl commands"
         ]
         commands_message = "\n".join(commands_list)
@@ -59,7 +273,7 @@ class QuantumPterodactyl(commands.Cog):
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
-            "Accept": "Application/vnd.pterodactyl.v1+json"
+            "Accept": "application/json"
         }
         data = {"signal": signal}
 
@@ -79,71 +293,65 @@ class QuantumPterodactyl(commands.Cog):
 
     power = app_commands.Group(name="power", description="Control server power state.")
     
-    @power.command(name="start")
-    @app_commands.checks.has_permissions(administrator=True)
-    async def start_server(self, interaction: discord.Interaction):
-        """Starts the game server"""
-        await interaction.response.defer()
-        
-        success, message = await self._send_power_signal("start")
-        if success:
-            await interaction.followup.send("🟢 Server is starting up...")
-            self.logger.info("Server is starting up")
-        else:
-            await interaction.followup.send(f"❌ Failed to start server: {message}")
-            self.logger.error(f"Failed to start server: {message}")
-
     @power.command(name="stop")
     @app_commands.checks.has_permissions(administrator=True)
-    async def stop_server(self, interaction: discord.Interaction):
-        """Stops the game server gracefully"""
-        await interaction.response.defer()
+    async def stop_server(self, interaction: discord.Interaction, server_id: str):
+        """Stops the specified game server gracefully"""
+        await interaction.response.defer() #Discord: with interactions its common to defer the response so that the interaction doesn't time out (3s) while the command is being processed
+
+        success, message = await self._send_power_signal("stop", server_id)
         
-        success, message = await self._send_power_signal("stop")
         if success:
-            await interaction.followup.send("🔴 Server is shutting down...")
-            self.logger.info("Server is shutting down")
+            await interaction.followup.send(f"🔴 Server `{server_id}` is shutting down...")
+            self.logger.info(f"Server `{server_id}` is shutting down")
         else:
-            await interaction.followup.send(f"❌ Failed to stop server: {message}")
-            self.logger.error(f"Failed to stop server: {message}")
+            await interaction.followup.send(f"❌ Failed to stop server `{server_id}`: {message}")
+            self.logger.error(f"Failed to stop server `{server_id}`: {message}")
 
     @power.command(name="restart")
     @app_commands.checks.has_permissions(administrator=True)
-    async def restart_server(self, interaction: discord.Interaction):
-        """Restarts the game server"""
-        await interaction.response.defer()
+    async def restart_server(self, interaction: discord.Interaction, server_id: str):
+        """Restarts the specified game server"""
+        await interaction.response.defer() #Discord: Defer all interactions which may take longer than 3 seconds to respond
+
+        success, message = await self._send_power_signal("restart", server_id)
         
-        success, message = await self._send_power_signal("restart")
         if success:
-            await interaction.followup.send("🔄 Server is restarting...")
-            self.logger.info("Server is restarting")
+            await interaction.followup.send(f"🔄 Server `{server_id}` is restarting...")
+            self.logger.info(f"Server `{server_id}` is restarting")
         else:
-            await interaction.followup.send(f"❌ Failed to restart server: {message}")
-            self.logger.error(f"Failed to restart server: {message}")
+            await interaction.followup.send(f"❌ Failed to restart server `{server_id}`: {message}")
+            self.logger.error(f"Failed to restart server `{server_id}`: {message}")
 
     @power.command(name="kill")
     @app_commands.checks.has_permissions(administrator=True)
-    async def kill_server(self, interaction: discord.Interaction):
-        """Forcefully stops the game server"""
-        await interaction.response.defer()
+    async def kill_server(self, interaction: discord.Interaction, server_id: str):
+        """Forcefully stops the specified game server"""
+        await interaction.response.defer() 
+
+        success, message = await self._send_power_signal("kill", server_id)
         
-        success, message = await self._send_power_signal("kill")
         if success:
-            await interaction.followup.send("⚠️ Server has been forcefully stopped!")
-            self.logger.warning("Server has been forcefully stopped")
+            await interaction.followup.send(f"⚠️ Server `{server_id}` has been forcefully stopped!")
+            self.logger.warning(f"Server `{server_id}` has been forcefully stopped")
         else:
-            await interaction.followup.send(f"❌ Failed to kill server: {message}")
-            self.logger.error(f"Failed to kill server: {message}")
+            await interaction.followup.send(f"❌ Failed to kill server `{server_id}`: {message}")
+            self.logger.error(f"Failed to kill server `{server_id}`: {message}")
             
-    server = app_commands.Group(name="server", description="Server information.")
+    server = app_commands.Group(name="server", description="Server information.") #Discord: Define the app command group for 'server' commands
     
-    @server.command(name='info', description='Get server information')
-    async def server_info(self, interaction: discord.Interaction):
-        await interaction.response.defer()  # Defer the response while fetching data
-        url = f"{self.panel_url}/api/client"
+    @server.command(name="list", description="List all game servers")
+    @app_commands.checks.has_permissions(administrator=True, manage_guild=True)
+    async def list_servers(self, interaction: discord.Interaction):
+        """
+        Lists all servers associated with the Pterodactyl panel.
+        """
+        await interaction.response.defer() 
+
+        url = f"{self.panel_url}/api/client/servers"
         headers = {
-            "Accept": "application/json",
-            "Authorization": f"Bearer {self.api_key}"
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json"
         }
 
         try:
@@ -151,33 +359,109 @@ class QuantumPterodactyl(commands.Cog):
                 async with session.get(url, headers=headers) as response:
                     if response.status == 200:
                         data = await response.json()
-                        server_info = data.get('attributes', {})
+                        server_list = [f"**{server['attributes']['name']}** (ID: {server['attributes']['id']})" for server in data['data']]
 
-                        # Format and send server info
                         embed = discord.Embed(
-                            title="Server Information",
-                            description="Details",
+                            title="Pterodactyl Servers",
+                            description="\n".join(server_list),
                             color=discord.Color.purple()
                         )
-                        embed.add_field(name="Identifier", value=server_info.get("identifier", "N/A"), inline=False)
-                        embed.add_field(name="Name", value=server_info.get("name", "N/A"), inline=False)
-                        embed.add_field(name="Node", value=server_info.get("node", "N/A"), inline=False)
-                        embed.add_field(name="SFTP Details", value=f"Host: {server_info.get('sftp_details', {}).get('ip', 'N/A')}\nPort: {server_info.get('sftp_details', {}).get('port', 'N/A')}", inline=False)
-                        embed.add_field(name="Description", value=server_info.get("description", "N/A"), inline=False)
-                        embed.add_field(name="CPU Usage", value=f"{server_info.get('cpu', 'N/A')}%", inline=False)
-                        embed.add_field(name="Memory Usage", value=f"{server_info.get('memory', 'N/A')} MB", inline=False)
-                        
                         await interaction.followup.send(embed=embed)
-                        self.logger.info("Server info fetched successfully.")
                     else:
                         error_text = await response.text()
-                        await interaction.followup.send(f"Failed to fetch server info. Status: {response.status}")
-                        self.logger.error(f"Failed to fetch server info: {error_text}")
+                        self.logger.error(f"Pterodactyl API error: {error_text}")
+                        await interaction.followup.send(f"❌ Failed to list servers. Status: {response.status}")
         except Exception as e:
-            await interaction.followup.send(f"An error occurred while fetching server info: {str(e)}")
-            self.logger.error(f"Error fetching server info: {str(e)}")
+            self.logger.error(f"Error listing servers: {str(e)}")
+            await interaction.followup.send(f"❌ Error occurred: {str(e)}")
+        
+        
+    @server.command(name="details", description="Get detailed information about a specific server")
+    @app_commands.checks.has_permissions(administrator=True, manage_guild=True)
+    async def server_details(self, interaction: discord.Interaction, server_id: str = None):
+        """Fetches and displays detailed server information."""
+        await interaction.response.defer()
 
+        # Use provided server_id or default to self.server_id
+        server_id = server_id or self.server_id
+        url = f"{self.panel_url}/api/application/servers/{server_id}"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        }
 
-async def setup(bot):
-    await bot.add_cog(QuantumPterodactyl(bot))
-    bot.logger.info("Cog loaded: QuantumPterodactyl v0.1")
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, headers=headers) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        attributes = data['attributes']
+
+                        # Extract core data, we can add more fields if needed this is not an exhaustive list of attributes
+                        server_name = attributes.get("name", "N/A")
+                        description = attributes.get("description", "No description provided")
+                        uuid = attributes.get("uuid", "N/A")
+                        identifier = attributes.get("identifier", "N/A")
+                        suspended = "Yes" if attributes.get("suspended") else "No"
+
+                        # Limits
+                        limits = attributes.get("limits", {})
+                        memory = limits.get("memory", "N/A")
+                        swap = limits.get("swap", "N/A")
+                        disk = limits.get("disk", "N/A")
+                        io = limits.get("io", "N/A")
+                        cpu = limits.get("cpu", "N/A")
+
+                        # Feature Limits
+                        feature_limits = attributes.get("feature_limits", {})
+                        databases = feature_limits.get("databases", "N/A")
+                        allocations = feature_limits.get("allocations", "N/A")
+                        backups = feature_limits.get("backups", "N/A")
+
+                        # Container Information
+                        container = attributes.get("container", {})
+                        startup_command = container.get("startup_command", "N/A")
+                        image = container.get("image", "N/A")
+                        installed = "Yes" if container.get("installed") else "No"
+
+                        # Embed creation
+                        embed = discord.Embed(
+                            title=f"Server Details: {server_name}",
+                            description=description,
+                            color=discord.Color.purple()
+                        )
+                        embed.add_field(name="UUID", value=uuid, inline=False)
+                        embed.add_field(name="Identifier", value=identifier, inline=True)
+                        embed.add_field(name="Suspended", value=suspended, inline=True)
+
+                        # Limits
+                        embed.add_field(name="Memory Limit", value=f"{memory} MB", inline=True)
+                        embed.add_field(name="Swap Limit", value=f"{swap} MB", inline=True)
+                        embed.add_field(name="Disk Limit", value=f"{disk} MB", inline=True)
+                        embed.add_field(name="I/O Limit", value=io, inline=True)
+                        embed.add_field(name="CPU Limit", value=cpu, inline=True)
+
+                        # Feature Limits
+                        embed.add_field(name="Databases", value=databases, inline=True)
+                        embed.add_field(name="Allocations", value=allocations, inline=True)
+                        embed.add_field(name="Backups", value=backups, inline=True)
+
+                        # Container Info
+                        embed.add_field(name="Startup Command", value=startup_command, inline=False)
+                        embed.add_field(name="Image", value=image, inline=True)
+                        embed.add_field(name="Installed", value=installed, inline=True)
+
+                        # Additional Information
+                        embed.set_footer(text=f"Created at: {attributes.get('created_at', 'N/A')}\nUpdated at: {attributes.get('updated_at', 'N/A')}")
+
+                        await interaction.followup.send(embed=embed)
+                        self.logger.info(f"Server details fetched successfully for server ID: {server_id}")
+                    else:
+                        error_text = await response.text()
+                        self.logger.error(f"Pterodactyl API error: {error_text}")
+                        await interaction.followup.send(f"❌ Failed to fetch server details. Status: {response.status}")
+        except Exception as e:
+            self.logger.error(f"Error fetching server details: {str(e)}")
+            await interaction.followup.send(f"❌ Error occurred: {str(e)}")
+

--- a/cogs/quantum_pterodactyl/quantum_pterodactyl.py
+++ b/cogs/quantum_pterodactyl/quantum_pterodactyl.py
@@ -35,6 +35,7 @@ class QuantumPterodactyl(commands.Cog):
     async def list_commands(self, interaction: discord.Interaction):
         """QuantumPterodactyl command list:"""
         commands_list = [
+            "/server list - List all PteroDactyl game servers",
             "/power state <serverid:str> - Get the current state of the game server",
             "/power start <serverid:str> - Starts the game server",
             "/power stop <serverid:str> - Stops the game server gracefully",

--- a/cogs/rcon_commands/qc_rcon_commands.py
+++ b/cogs/rcon_commands/qc_rcon_commands.py
@@ -1,15 +1,15 @@
-import discord 
+import discord
 from discord import app_commands
 from discord.ext import commands
 from dotenv import load_dotenv
 import asyncio
 import os
-import time 
+import time
 from discord.ext.commands import has_permissions
 from typing import Optional
 from mcrcon import MCRcon
 
-#* Define the intents for the bot (this is required for the discord-py-slash-commands library)) 
+# * Define the intents for the bot (this is required for the discord-py-slash-commands library))
 intents = discord.Intents.default()
 intents.message_content = True
 intents.messages = True
@@ -17,34 +17,41 @@ intents.guilds = True
 intents.reactions = True
 intents.members = True
 
-#* Load the .env to get the rcon server details
+# * Load the .env to get the rcon server details
 load_dotenv()
 
-rcon_host=str(os.getenv("RCON_HOST"))
-rcon_password=str(os.getenv("RCON_PASSWORD"))
-rcon_port=int(os.getenv("RCON_PORT"))
+rcon_host = str(os.getenv("RCON_HOST"))
+rcon_password = str(os.getenv("RCON_PASSWORD"))
+rcon_port = int(os.getenv("RCON_PORT"))
 
-#section Code defining the Cog and its attributes/functions
+# section Code defining the Cog and its attributes/functions
+
 
 class Quantum_RCON_Commands_Cog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.logger = bot.logger
-    
-    #discord - rcon command group for use with the discord-py-slash-commands library, this will group the rcon related commands beneath /rcon.
-    #discord - due to the number of commands, the rcon command group is further split into subgroups for better organisation. (world, ) 
-    rcon = app_commands.Group(name="rcon", description="Send RCON commands to the Minecraft Server.")
-    @rcon.command(name="say", description="Send a message from the Bot to the server. Usage <message>")
+
+    # discord - rcon command group for use with the discord-py-slash-commands library, this will group the rcon related commands beneath /rcon.
+    # discord - due to the number of commands, the rcon command group is further split into subgroups for better organisation. (world, )
+    rcon = app_commands.Group(
+        name="rcon", description="Send RCON commands to the Minecraft Server."
+    )
+
+    @rcon.command(
+        name="say",
+        description="Send a message from the Bot to the server. Usage <message>",
+    )
     async def say(self, *thing_to_say: str):
-        """ Send a message from the Bot to the server. Usage <message>"""
+        """Send a message from the Bot to the server. Usage <message>"""
         command = f"say {thing_to_say}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
             self.logger.info(f"Bot said {thing_to_say} in the server chat.")
-        
+
     @rcon.command(name="status", description="Check the server status.")
     async def status(self, Interaction: discord.Interaction):
-        """ Check the server status."""
+        """Check the server status."""
         try:
             start_time = time.time()
             command = f"status"
@@ -52,72 +59,113 @@ class Quantum_RCON_Commands_Cog(commands.Cog):
                 response = mcr.command(command)
                 end_time = time.time()
             # get the ping of the server, start time - end time * 1000 to get the latency in ms
-            latency = round((end_time - start_time) * 1000)  
-            await Interaction.response.send_message(f"Server Status: {response}\nLatency: {latency}ms")
+            latency = round((end_time - start_time) * 1000)
+            await Interaction.response.send_message(
+                f"Server Status: {response}\nLatency: {latency}ms"
+            )
             self.logger.info(f"Server Status: {response}\nLatency: {latency}ms")
         except Exception as e:
-            await Interaction.response.send_message(f"Failed to retrieve server status: {e}")
+            await Interaction.response.send_message(
+                f"Failed to retrieve server status: {e}"
+            )
             self.logger.error(f"Failed to retrieve server status: {e}")
-            
-    @rcon.command(name="weather", description="Change the weather. Usage <weather_type> \n Valid weather types: clear, rain, thunder")
+
+    @rcon.command(
+        name="weather",
+        description="Change the weather. Usage <weather_type> \n Valid weather types: clear, rain, thunder",
+    )
     @has_permissions(manage_channels=True)
     async def weather(self, Interaction: discord.Interaction, weather_type: str):
-        """ Change the weather. Usage <weather_type> \n Valid weather types: clear, rain, thunder"""
+        """Change the weather. Usage <weather_type> \n Valid weather types: clear, rain, thunder"""
         valid_types = ["clear", "rain", "thunder"]
         if weather_type.lower() not in valid_types:
-            await Interaction.response.send_message("Invalid weather type. Choose from clear, rain, or thunder.")
-            self.logger.warning(f"{Interaction.user} attempted to set an Invalid weather type: {weather_type}")
+            await Interaction.response.send_message(
+                "Invalid weather type. Choose from clear, rain, or thunder."
+            )
+            self.logger.warning(
+                f"{Interaction.user} attempted to set an Invalid weather type: {weather_type}"
+            )
             return
         command = f"/weather {weather_type}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Weather changed to {weather_type}.")
+            await Interaction.response.send_message(
+                f"Weather changed to {weather_type}."
+            )
             self.logger.info(f"{Interaction.user} changed Weather to {weather_type}.")
-                
-    @rcon.command(name="ablity" , description="Set a player's ability value. Usage <player> <ability> <value>")
+
+    @rcon.command(
+        name="ablity",
+        description="Set a player's ability value. Usage <player> <ability> <value>",
+    )
     @has_permissions(manage_channels=True)
-    async def ability(self, Interaction: discord.Interaction, player: str, ability: str, value: int):
-        """ Set a player's ability value. Usage <player> <ability> <value>"""
+    async def ability(
+        self, Interaction: discord.Interaction, player: str, ability: str, value: int
+    ):
+        """Set a player's ability value. Usage <player> <ability> <value>"""
         command = f"{player} {ability} {value}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"{player} ability: {ability} set to {value}.") 
-            self.logger.info(f"{Interaction.user} set {player} ability: {ability} to {value}.")
-            
-    @rcon.command(name="advancement" , description="Grant or revoke advancements to players. Usage <player> <action> <advancement>")
+            await Interaction.response.send_message(
+                f"{player} ability: {ability} set to {value}."
+            )
+            self.logger.info(
+                f"{Interaction.user} set {player} ability: {ability} to {value}."
+            )
+
+    @rcon.command(
+        name="advancement",
+        description="Grant or revoke advancements to players. Usage <player> <action> <advancement>",
+    )
     @has_permissions(manage_channels=True)
-    async def advancement(self, Interaction: discord.Interaction, player: str, action: str, advancement: str):
-        """ Grant or revoke advancements to players. Usage <player> <action> <advancement>"""
+    async def advancement(
+        self,
+        Interaction: discord.Interaction,
+        player: str,
+        action: str,
+        advancement: str,
+    ):
+        """Grant or revoke advancements to players. Usage <player> <action> <advancement>"""
         command = f"{player} {action} {advancement}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"{player} was {action} {advancement}.") 
+            await Interaction.response.send_message(
+                f"{player} was {action} {advancement}."
+            )
             self.logger.info(f"{Interaction.user} {player} {action} {advancement}.")
 
-    @rcon.command(name="ban", description="Ban a player from the server. Usage <player>")
+    @rcon.command(
+        name="ban", description="Ban a player from the server. Usage <player>"
+    )
     @has_permissions(manage_channels=True)
     async def ban(self, Interaction: discord.Interaction, player: str):
-        """ Ban a player from the server. Usage <player>"""
+        """Ban a player from the server. Usage <player>"""
         command = f"ban {player}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"{player} has been banned from the server.")
+            await Interaction.response.send_message(
+                f"{player} has been banned from the server."
+            )
             self.logger.info(f"{Interaction.user} banned {player}.")
 
-    @rcon.command(name="ban-ip", description="Ban an IP address from the server. Usage <ip>")
+    @rcon.command(
+        name="ban-ip", description="Ban an IP address from the server. Usage <ip>"
+    )
     @has_permissions(manage_channels=True)
     async def ban_ip(self, Interaction: discord.Interaction, ip: str):
-        """ Ban an IP address from the server. Usage <ip>"""
+        """Ban an IP address from the server. Usage <ip>"""
         command = f"ban-ip {ip}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"{ip} has been banned from the server.")
+            await Interaction.response.send_message(
+                f"{ip} has been banned from the server."
+            )
             self.logger.info(f"{Interaction.user} IP banned {ip}.")
 
     @rcon.command(name="banlist", description="List all banned players.")
     @has_permissions(manage_channels=True)
     async def banlist(self, Interaction: discord.Interaction):
-        """ List all banned players."""
+        """List all banned players."""
         command = "banlist"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
@@ -127,116 +175,231 @@ class Quantum_RCON_Commands_Cog(commands.Cog):
                 await Interaction.response.send_message("No players are banned.")
             self.logger.info(f"{Interaction.user} listed banned players.")
 
-    @rcon.command(name="clear", description="Clear items from a player's inventory. Usage <player> [item] [count]")
+    @rcon.command(
+        name="clear",
+        description="Clear items from a player's inventory. Usage <player> [item] [count]",
+    )
     @has_permissions(manage_channels=True)
-    async def clear(self, Interaction: discord.Interaction, player: str, item: str=None, count: int=None):
-        """ Clear items from a player's inventory. Usage <player> [item] [count]"""
-        command = f"clear {player} {item if item else ''} {count if count else ''}".strip()
+    async def clear(
+        self,
+        Interaction: discord.Interaction,
+        player: str,
+        item: str = None,
+        count: int = None,
+    ):
+        """Clear items from a player's inventory. Usage <player> [item] [count]"""
+        command = (
+            f"clear {player} {item if item else ''} {count if count else ''}".strip()
+        )
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Cleared items from {player}'s inventory.")
-            self.logger.info(f'{Interaction.user} Cleared items from {player} inventory.')
+            await Interaction.response.send_message(
+                f"Cleared items from {player}'s inventory."
+            )
+            self.logger.info(
+                f"{Interaction.user} Cleared items from {player} inventory."
+            )
 
-    @rcon.command(name="clone", description="Clone blocks. Usage <start_pos> <end_pos> <destination> [mask_mode] [clone_mode] [tile_mode]")
+    @rcon.command(
+        name="clone",
+        description="Clone blocks. Usage <start_pos> <end_pos> <destination> [mask_mode] [clone_mode] [tile_mode]",
+    )
     @has_permissions(manage_channels=True)
-    async def clone(self, Interaction: discord.Interaction, start_pos: int, end_pos: int, destination: int, mask_mode: bool=None, clone_mode: bool=None, tile_mode: bool=None):
-        """ Clone blocks. Usage <start_pos> <end_pos> <destination> [mask_mode] [clone_mode] [tile_mode]"""
+    async def clone(
+        self,
+        Interaction: discord.Interaction,
+        start_pos: int,
+        end_pos: int,
+        destination: int,
+        mask_mode: bool = None,
+        clone_mode: bool = None,
+        tile_mode: bool = None,
+    ):
+        """Clone blocks. Usage <start_pos> <end_pos> <destination> [mask_mode] [clone_mode] [tile_mode]"""
         command = f"clone {start_pos} {end_pos} {destination} {mask_mode if mask_mode else ''} {clone_mode if clone_mode else ''} {tile_mode if tile_mode else ''}".strip()
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-        await Interaction.response.send_message(f"Blocks cloned from {start_pos} to {end_pos} to {destination}." + (f" with mask mode {mask_mode}" if mask_mode else "") + (f", clone mode {clone_mode}" if clone_mode else "") + (f", tile mode {tile_mode}" if tile_mode else "") + ".")
+        await Interaction.response.send_message(
+            f"Blocks cloned from {start_pos} to {end_pos} to {destination}."
+            + (f" with mask mode {mask_mode}" if mask_mode else "")
+            + (f", clone mode {clone_mode}" if clone_mode else "")
+            + (f", tile mode {tile_mode}" if tile_mode else "")
+            + "."
+        )
 
-    @rcon.command(name="damage", description="Damage entities. Usage <entities> <amount>")
-    async def damage(self, Interaction: discord.Interaction, entities: str, amount: int):
-        """ Damage entities. Usage <entities> <amount>"""
+    @rcon.command(
+        name="damage", description="Damage entities. Usage <entities> <amount>"
+    )
+    async def damage(
+        self, Interaction: discord.Interaction, entities: str, amount: int
+    ):
+        """Damage entities. Usage <entities> <amount>"""
         command = f"damage {entities} {amount}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
         await Interaction.response.send_message(f"Damaged {entities} by {amount}.")
-    
-    @rcon.command(name="daylock", description="Lock or unlock the day-night cycle. Alias: alwaysday. Usage <action>")
+
+    @rcon.command(
+        name="daylock",
+        description="Lock or unlock the day-night cycle. Alias: alwaysday. Usage <action>",
+    )
     @has_permissions(manage_channels=True)
     async def daylock(self, Interaction: discord.Interaction, action: str):
-        """ Lock or unlock the day-night cycle. Alias: alwaysday. Usage <action>"""
+        """Lock or unlock the day-night cycle. Alias: alwaysday. Usage <action>"""
         command = f"daylock {action}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
         await Interaction.response.send_message(f"Daylock {action}.")
 
-    @rcon.command(name="difficulty", description="Change the game difficulty. Usage <level>")
+    @rcon.command(
+        name="difficulty", description="Change the game difficulty. Usage <level>"
+    )
     @has_permissions(manage_channels=True)
     async def difficulty(self, Interaction: discord.Interaction, level: int):
-        """ Change the game difficulty. Usage <level>"""
+        """Change the game difficulty. Usage <level>"""
         command = f"difficulty {level}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
             await Interaction.response.send_message(f"Game difficulty set to {level}.")
-            
-    @rcon.command(name="gamerule", description="Set or query a game rule value. Usage <rule> [value]")
+
+    @rcon.command(
+        name="gamerule",
+        description="Set or query a game rule value. Usage <rule> [value]",
+    )
     @has_permissions(manage_channels=True)
-    async def gamerule(self, Interaction: discord.Interaction, rule: str, value: str=None):
-        """ Set or query a game rule value. Usage <rule> [value]"""
+    async def gamerule(
+        self, Interaction: discord.Interaction, rule: str, value: str = None
+    ):
+        """Set or query a game rule value. Usage <rule> [value]"""
         command = f"gamerule {rule} {value if value else ''}".strip()
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-        await Interaction.response.send_message(f"Game rule {rule} set to {value}." if value else f"Game rule {rule} is {response}.")
-            
-    @rcon.command(name="effect", description="Give an effect to a player or entity. Usage <target> <effect> [duration] [amplifier]")
+        await Interaction.response.send_message(
+            f"Game rule {rule} set to {value}."
+            if value
+            else f"Game rule {rule} is {response}."
+        )
+
+    @rcon.command(
+        name="effect",
+        description="Give an effect to a player or entity. Usage <target> <effect> [duration] [amplifier]",
+    )
     @has_permissions(manage_channels=True)
-    async def effect(self, Interaction: discord.Interaction, target: str, effect: str, duration: int=None, amplifier: str=None):
-        """ Give an effect to a player or entity. Usage <target> <effect> [duration] [amplifier]"""
+    async def effect(
+        self,
+        Interaction: discord.Interaction,
+        target: str,
+        effect: str,
+        duration: int = None,
+        amplifier: str = None,
+    ):
+        """Give an effect to a player or entity. Usage <target> <effect> [duration] [amplifier]"""
         command = f"effect give {target} {effect} {duration if duration else ''} {amplifier if amplifier else ''}".strip()
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Effect {effect} given to {target}.")
+            await Interaction.response.send_message(
+                f"Effect {effect} given to {target}."
+            )
 
-    @rcon.command(name="enchantment", description="Enchant a player item. Usage <player> <enchantment> [level]")
+    @rcon.command(
+        name="enchantment",
+        description="Enchant a player item. Usage <player> <enchantment> [level]",
+    )
     @has_permissions(manage_channels=True)
-    async def enchant(self, Interaction: discord.Interaction, player: str, enchantment: str, level: int= None):
-        """ Enchant a player item. Usage <player> <enchantment> [level]"""
+    async def enchant(
+        self,
+        Interaction: discord.Interaction,
+        player: str,
+        enchantment: str,
+        level: int = None,
+    ):
+        """Enchant a player item. Usage <player> <enchantment> [level]"""
         command = f"enchant {player} {enchantment} {level if level else ''}".strip()
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Enchantment {enchantment} applied to {player}.")
-            
-    #discord - creation of world command group .  
-    world = app_commands.Group(name="world", description="Send RCON commands to the Minecraft Server - Manage World Attributes.")
-    @world.command(name="fill", description="Fill a region with a specific block. Usage <start_pos> <end_pos> <block> [mode]")
-    async def fill(self, Interaction: discord.Interaction, start_pos: int, end_pos: int, block: str, mode: str=None):
-        """ Fill a region with a specific block. Usage <start_pos> <end_pos> <block> [mode]"""
+            await Interaction.response.send_message(
+                f"Enchantment {enchantment} applied to {player}."
+            )
+
+    # discord - creation of world command group .
+    world = app_commands.Group(
+        name="world",
+        description="Send RCON commands to the Minecraft Server - Manage World Attributes.",
+    )
+
+    @world.command(
+        name="fill",
+        description="Fill a region with a specific block. Usage <start_pos> <end_pos> <block> [mode]",
+    )
+    async def fill(
+        self,
+        Interaction: discord.Interaction,
+        start_pos: int,
+        end_pos: int,
+        block: str,
+        mode: str = None,
+    ):
+        """Fill a region with a specific block. Usage <start_pos> <end_pos> <block> [mode]"""
         command = f"fill {start_pos} {end_pos} {block} {mode if mode else ''}".strip()
         async with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Filled region from {start_pos} to {end_pos} with {block}." + (f" in mode {mode}" if mode else "") + ".")
+            await Interaction.response.send_message(
+                f"Filled region from {start_pos} to {end_pos} with {block}."
+                + (f" in mode {mode}" if mode else "")
+                + "."
+            )
 
-    @world.command(name="fillbiome", description="Fill a region with a specific biome. Usage <start_pos> <end_pos> <biome>")
+    @world.command(
+        name="fillbiome",
+        description="Fill a region with a specific biome. Usage <start_pos> <end_pos> <biome>",
+    )
     @has_permissions(manage_channels=True)
-    async def fillbiome(self, Interaction: discord.Interaction, start_pos: int, end_pos: int, biome: str):
-        """ Fill a region with a specific biome. Usage <start_pos> <end_pos> <biome>"""
+    async def fillbiome(
+        self, Interaction: discord.Interaction, start_pos: int, end_pos: int, biome: str
+    ):
+        """Fill a region with a specific biome. Usage <start_pos> <end_pos> <biome>"""
         command = f"fillbiome {start_pos} {end_pos} {biome}"
         async with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Filled region from {start_pos} to {end_pos} with {biome}.")
+            await Interaction.response.send_message(
+                f"Filled region from {start_pos} to {end_pos} with {biome}."
+            )
 
-    @rcon.command(name="give", description="Give items to a player. Usage <player> <item> <amount>")
+    @rcon.command(
+        name="give",
+        description="Give items to a player. Usage <player> <item> <amount>",
+    )
     @has_permissions(manage_channels=True)
-    async def give(self, Interaction: discord.Interaction, player: str, item: str, amount: int):
-        """ Give items to a player. Usage <player> <item> <amount>"""
+    async def give(
+        self, Interaction: discord.Interaction, player: str, item: str, amount: int
+    ):
+        """Give items to a player. Usage <player> <item> <amount>"""
         command = f"give {player} {item} {amount}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Gave {amount} of {item} to {player}.")
+            await Interaction.response.send_message(
+                f"Gave {amount} of {item} to {player}."
+            )
 
-    @rcon.command(name="kick", description="Kick a player from the server. Usage <player> [reason]")
+    @rcon.command(
+        name="kick",
+        description="Kick a player from the server. Usage <player> [reason]",
+    )
     @has_permissions(manage_channels=True)
-    async def kick(self, Interaction: discord.Interaction, player: str,  *, reason: str=None):
-        """ Kick a player from the server. Usage <player> [reason]"""
+    async def kick(
+        self, Interaction: discord.Interaction, player: str, *, reason: str = None
+    ):
+        """Kick a player from the server. Usage <player> [reason]"""
         command = f"kick {player} {reason}" if reason else f"kick {player}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"{player} has been kicked from the server. Reason: {reason}" if reason else f"{player} has been kicked from the server.")
+            await Interaction.response.send_message(
+                f"{player} has been kicked from the server. Reason: {reason}"
+                if reason
+                else f"{player} has been kicked from the server."
+            )
 
-    #todo complete this function
+    # todo complete this function
     # Function for the /kill command
     def kill(entities):
         pass
@@ -244,25 +407,48 @@ class Quantum_RCON_Commands_Cog(commands.Cog):
     @rcon.command(name="listplayers", description="List all players on the server.")
     @has_permissions(manage_channels=True)
     async def list_players(self, Interaction: discord.Interaction):
-        """ List all players on the server."""
+        """List all players on the server."""
         command = "list"
-        with MCRcon(rcon_host, rcon_password, port=int(rcon_port)) as mcr:  # Ensure port is an integer
+        with MCRcon(
+            rcon_host, rcon_password, port=int(rcon_port)
+        ) as mcr:  # Ensure port is an integer
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Denizens on the server: {response}")
+            await Interaction.response.send_message(
+                f"Denizens on the server: {response}"
+            )
 
-    @rcon.command(name="op", description="Grant operator status to a player. Usage <player>")
+    @rcon.command(
+        name="op", description="Grant operator status to a player. Usage <player>"
+    )
     @has_permissions(manage_channels=True)
     async def op(self, Interaction: discord.Interaction, player: str):
-        """ Grant operator status to a player. Usage <player>"""
+        """Grant operator status to a player. Usage <player>"""
         command = "op"
-        async with MCRcon(rcon_host, rcon_password, port=int(rcon_port)) as mcr:  # Ensure port is an integer
+        async with MCRcon(
+            rcon_host, rcon_password, port=int(rcon_port)
+        ) as mcr:  # Ensure port is an integer
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Operator status granted to {player},  {response}")
+            await Interaction.response.send_message(
+                f"Operator status granted to {player},  {response}"
+            )
 
-    @world.command(name="place", description="Usage <feature> <x> <y> <z> [rotation] [mirror] [mode]")
+    @world.command(
+        name="place",
+        description="Usage <feature> <x> <y> <z> [rotation] [mirror] [mode]",
+    )
     @has_permissions(manage_channels=True)
-    async def place(self, Interaction: discord.Interaction, feature: str, x: int, y: int, z: int, rotation: int=None, mirror: bool=None, mode: str=None):
-        """ Place a feature at a location. Usage <feature> <x> <y> <z> [rotation] [mirror] [mode]"""
+    async def place(
+        self,
+        Interaction: discord.Interaction,
+        feature: str,
+        x: int,
+        y: int,
+        z: int,
+        rotation: int = None,
+        mirror: bool = None,
+        mode: str = None,
+    ):
+        """Place a feature at a location. Usage <feature> <x> <y> <z> [rotation] [mirror] [mode]"""
         command = f"setblock {x} {y} {z} {feature}"
         if rotation:
             command += f" rotation={rotation}"
@@ -272,97 +458,163 @@ class Quantum_RCON_Commands_Cog(commands.Cog):
             command += f" mode={mode}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Placed {feature} at ({x}, {y}, {z})" + (f" with rotation {rotation}" if rotation else "") + (f", mirror {mirror}" if mirror else "") + (f", in mode {mode}" if mode else "") + ".")
+            await Interaction.response.send_message(
+                f"Placed {feature} at ({x}, {y}, {z})"
+                + (f" with rotation {rotation}" if rotation else "")
+                + (f", mirror {mirror}" if mirror else "")
+                + (f", in mode {mode}" if mode else "")
+                + "."
+            )
 
     @world.command(name="seed", description="Get the world seed.")
     async def seed(self, Interaction: discord.Interaction):
-        """ Get the world seed."""
+        """Get the world seed."""
         command = "seed"
-        with MCRcon(rcon_host, rcon_password, port=int(rcon_port)) as mcr:  # Ensure port is an integer
+        with MCRcon(
+            rcon_host, rcon_password, port=int(rcon_port)
+        ) as mcr:  # Ensure port is an integer
             response = mcr.command(command)
             await Interaction.response.send_message(f"World seed: {response}")
 
-    @world.command(name="setblock", description="Place a block at a location. Usage <x> <y> <z> <block> [mode]")
+    @world.command(
+        name="setblock",
+        description="Place a block at a location. Usage <x> <y> <z> <block> [mode]",
+    )
     @has_permissions(manage_channels=True)
-    async def setblock(self, Interaction: discord.Interaction, x: int, y: int, z: int, block: str, mode:str=None):
-        """ Place a block at a location. Usage <x> <y> <z> <block> [mode]"""
+    async def setblock(
+        self,
+        Interaction: discord.Interaction,
+        x: int,
+        y: int,
+        z: int,
+        block: str,
+        mode: str = None,
+    ):
+        """Place a block at a location. Usage <x> <y> <z> <block> [mode]"""
         command = f"setblock {x} {y} {z} {block}" + (f" {mode}" if mode else "")
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Block {block} placed at ({x}, {y}, {z})" + (f" in mode {mode}" if mode else "") + ".")
+            await Interaction.response.send_message(
+                f"Block {block} placed at ({x}, {y}, {z})"
+                + (f" in mode {mode}" if mode else "")
+                + "."
+            )
 
-    @rcon.command(name="setidletimeout", description="Set the idle timeout for players. Usage <timeout>")
+    @rcon.command(
+        name="setidletimeout",
+        description="Set the idle timeout for players. Usage <timeout>",
+    )
     @has_permissions(manage_channels=True)
     async def setidletimeout(self, Interaction: discord.Interaction, timeout: int):
-        """ Set the idle timeout for players. Usage <timeout>"""
+        """Set the idle timeout for players. Usage <timeout>"""
         command = f"setidletimeout {timeout}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Idle timeout set to {timeout} minutes.")
-            
-    @rcon.command(name="setmaxplayers", description="Set the maximum number of players. Usage <max_players>")
+            await Interaction.response.send_message(
+                f"Idle timeout set to {timeout} minutes."
+            )
+
+    @rcon.command(
+        name="setmaxplayers",
+        description="Set the maximum number of players. Usage <max_players>",
+    )
     @has_permissions(manage_channels=True)
     async def setmaxplayers(self, Interaction: discord.Interaction, max_players: int):
-        """ Set the maximum number of players. Usage <max_players>"""
+        """Set the maximum number of players. Usage <max_players>"""
         command = f"setmaxplayers {max_players}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Maximum players set to {max_players}.")
+            await Interaction.response.send_message(
+                f"Maximum players set to {max_players}."
+            )
 
-    @world.command(name="setworldspawn", description="Set the world spawn. Usage [x y z]")
+    @world.command(
+        name="setworldspawn", description="Set the world spawn. Usage [x y z]"
+    )
     @has_permissions(manage_channels=True)
-    async def setworldspawn(self, Interaction: discord.Interaction, x: int, y: int, z: int):
-        """ Set the world spawn. Usage [x y z]"""
+    async def setworldspawn(
+        self, Interaction: discord.Interaction, x: int, y: int, z: int
+    ):
+        """Set the world spawn. Usage [x y z]"""
         command = f"setworldspawn {x} {y} {z}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"World spawn set to ({x}, {y}, {z}).")
+            await Interaction.response.send_message(
+                f"World spawn set to ({x}, {y}, {z})."
+            )
 
-    @world.command(name="setspawnpoint", description="Set the world spawn. Usage [x y z]")
-    async def spawnpoint(self, Interaction: discord.Interaction, player: str,  pos: str=None):
-        """ Set the world spawn. Usage [x y z]"""
+    @world.command(
+        name="setspawnpoint", description="Set the world spawn. Usage [x y z]"
+    )
+    async def spawnpoint(
+        self, Interaction: discord.Interaction, player: str, pos: str = None
+    ):
+        """Set the world spawn. Usage [x y z]"""
         command = f"spawnpoint {player} {pos}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-        await Interaction.response.send_message(f"Spawnpoint set to {pos} for {player}.")
+        await Interaction.response.send_message(
+            f"Spawnpoint set to {pos} for {player}."
+        )
 
-
-    @rcon.command(name="summon", description="Summon an entity. Usage <entity> <x> <y> <z>")
+    @rcon.command(
+        name="summon", description="Summon an entity. Usage <entity> <x> <y> <z>"
+    )
     @has_permissions(manage_channels=True)
-    async def summon(self, Interaction: discord.Interaction, entity: str, x: int, y: int, z: int):
-        """ Summon an entity. Usage <entity> <x> <y> <z>"""
+    async def summon(
+        self, Interaction: discord.Interaction, entity: str, x: int, y: int, z: int
+    ):
+        """Summon an entity. Usage <entity> <x> <y> <z>"""
         command = f"summon {entity} {x} {y} {z}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Summoned {entity} at ({x}, {y}, {z}).")
+            await Interaction.response.send_message(
+                f"Summoned {entity} at ({x}, {y}, {z})."
+            )
 
-    @rcon.command(name="teleport", description="Teleport a player. Usage <player> <x> <y> <z>")
+    @rcon.command(
+        name="teleport", description="Teleport a player. Usage <player> <x> <y> <z>"
+    )
     @has_permissions(manage_channels=True)
-    async def teleport(self, Interaction: discord.Interaction, player: str, x: int, y: int, z: int):
-        """ Teleport a player. Usage <player> <x> <y> <z>"""
+    async def teleport(
+        self, Interaction: discord.Interaction, player: str, x: int, y: int, z: int
+    ):
+        """Teleport a player. Usage <player> <x> <y> <z>"""
         command = f"tp {player} {x} {y} {z}"
         with MCRcon(rcon_host, rcon_password, port=rcon_port) as mcr:
             response = mcr.command(command)
-            await Interaction.response.send_message(f"Teleported {player} to ({x}, {y}, {z}).")
+            await Interaction.response.send_message(
+                f"Teleported {player} to ({x}, {y}, {z})."
+            )
 
-    @world.command(name="time", description="Set or query the world time. Usage <action> [value]")
+    @world.command(
+        name="time", description="Set or query the world time. Usage <action> [value]"
+    )
     @has_permissions(manage_channels=True)
-    async def time(self, Interaction: discord.Interaction, action: str, value: Optional[int] = None):
-        """ Set or query the world time. Usage <action> [value]"""
+    async def time(
+        self, Interaction: discord.Interaction, action: str, value: Optional[int] = None
+    ):
+        """Set or query the world time. Usage <action> [value]"""
         if action.lower() == "set":
             if value is not None:
                 response = await self.rcon_command(f"time set {value}")
-                await Interaction.response.send_message(f"Time set to {value}. Server response: {response}")
+                await Interaction.response.send_message(
+                    f"Time set to {value}. Server response: {response}"
+                )
             else:
-                await Interaction.response.send_message("You need to provide a value for 'set' action.")
+                await Interaction.response.send_message(
+                    "You need to provide a value for 'set' action."
+                )
         elif action.lower() == "query":
             response = await self.rcon_command("time query daytime")
             await Interaction.response.send_message(f"Current time: {response}")
         else:
-            await Interaction.response.send_message("Invalid action. Use 'set' or 'query'.")
+            await Interaction.response.send_message(
+                "Invalid action. Use 'set' or 'query'."
+            )
 
 
-#discord setup function for the main bot to load the cog
+# discord setup function for the main bot to load the cog
 async def setup(bot):
-    """ Add the cog to the bot."""
+    """Add the cog to the bot."""
     await bot.add_cog(Quantum_RCON_Commands_Cog(bot))


### PR DESCRIPTION
Added serverid param to power commands.

Power commands group update
_send_power_signal will now accept an argument for server_id, which is passed to each of the power state commands. The server ID will be used to customize the api endpoint to address the command to a single server. This allows for more granular management of the server power states.

Added command 'power state <serverid:str>' which will call the pterodactyl resources API to retrieve the current state of the server.

Added server command 'server_list' which will return the names and IDs of Pterodactyl servers