### PR TITLE
Fix endpoint url concatenation, debug prints

### DIFF
--- a/cogs/quantum_pterodactyl/quantum_pterodactyl.py
+++ b/cogs/quantum_pterodactyl/quantum_pterodactyl.py
@@ -66,7 +66,7 @@ class QuantumPterodactyl(commands.Cog):
             signal (str): One of 'start', 'stop', 'restart', 'kill'
             server_id (str): The server ID to target for the power signal
         """
-        url = f"{self.panel_url}/api/client/servers/{server_id}/power"
+        url = f"{self.panel_url}api/client/servers/{server_id}/power"
         print(f'Sending {signal} signal to server {server_id}...') #! Debug Print
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -190,7 +190,8 @@ class QuantumPterodactyl(commands.Cog):
         """Fetches and displays the current power state of the specified server"""
         await Interaction.response.defer()
 
-        url = f"{self.panel_url}/api/client/servers/{server_id}/resources"
+        url = f"{self.panel_url}api/client/servers/{server_id}/resources"
+        print(f'url is {url}') #! Debug Print
         print(f'Fetching power state for server {server_id}...') #! Debug Print
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -240,7 +241,8 @@ class QuantumPterodactyl(commands.Cog):
         """
         await Interaction.response.defer()
 
-        url = f"{self.panel_url}/api/client/servers"
+        url = f"{self.panel_url}api/client/servers"
+        print(f'url is {url}') #! Debug Print
         print(f'Fetching server list from {url}') #! Debug Print
         headers = {
             "Authorization": f"Bearer {self.api_key}",


### PR DESCRIPTION
url was being constructed as panel.quantumlyconfused.com// (double slash) due to the value of the environment variable panel url.

Missed in the commit message: added a log buffer which will grab the last 100 log entries from memory and join them into a string to to put in a discord channel. I added a command to call this function, admin logbuffer. This will be useful to identify and debug issues quickly. 